### PR TITLE
Styling the Cashbook table to render it usable in edit mode.

### DIFF
--- a/truffe2/media/css/truffe.css
+++ b/truffe2/media/css/truffe.css
@@ -147,7 +147,7 @@
 }
 
 .desktop-detected .line_field_lines_date {
-	min-width: 100px;
+    min-width: 100px;
 	max-width: 120px;
 	width:6%;
 }

--- a/truffe2/media/css/truffe.css
+++ b/truffe2/media/css/truffe.css
@@ -148,44 +148,44 @@
 
 .desktop-detected .line_field_lines_date {
     min-width: 100px;
-	max-width: 120px;
-	width:6%;
+    max-width: 120px;
+    width:6%;
 }
 
 .desktop-detected .line_field_lines_helper {
-	max-width: 150px;
+    max-width: 150px;
 }
 .desktop-detected .line_field_lines_account {
-	max-width: 150px;
-	width: 10%;
+    max-width: 150px;
+    width: 10%;
 }
 
 .desktop-detected .line_field_lines_value {
-	min-width:100px;
-	max-width:120px;
-	width:6%;
+    min-width:100px;
+    max-width:120px;
+    width:6%;
 }
 
 .desktop-detected .line_field_lines_value_ttc {
-	min-width:100px;
-	max-width:120px;  
-	width:6%;
+    min-width:100px;
+    max-width:120px;  
+    width:6%;
 }
 
 .desktop-detected div.select2-drop{
-	min-width: 200px;
+    min-width: 200px;
 }
 
 .desktop-detected .line_field_lines_tva {
-	max-width: 110px;
+    max-width: 110px;
 }
 
 .desktop-detected .line_field_lines_label {
-	min-width:200px;
-	width:28%;
+    min-width:200px;
+    width:28%;
 }
 
 .desktop-detected .line_field_lines_proof {
-	min-width: 150px;
-	width:20%;
+    min-width: 150px;
+    width:20%;
 }

--- a/truffe2/media/css/truffe.css
+++ b/truffe2/media/css/truffe.css
@@ -145,3 +145,47 @@
 .login-info img {
     max-height: 27px;
 }
+
+.desktop-detected .line_field_lines_date {
+	min-width: 100px;
+	max-width: 120px;
+	width:6%;
+}
+
+.desktop-detected .line_field_lines_helper {
+	max-width: 150px;
+}
+.desktop-detected .line_field_lines_account {
+	max-width: 150px;
+	width: 10%;
+}
+
+.desktop-detected .line_field_lines_value {
+	min-width:100px;
+	max-width:120px;
+	width:6%;
+}
+
+.desktop-detected .line_field_lines_value_ttc {
+	min-width:100px;
+	max-width:120px;  
+	width:6%;
+}
+
+.desktop-detected div.select2-drop{
+	min-width: 200px;
+}
+
+.desktop-detected .line_field_lines_tva {
+	max-width: 110px;
+}
+
+.desktop-detected .line_field_lines_label {
+	min-width:200px;
+	width:28%;
+}
+
+.desktop-detected .line_field_lines_proof {
+	min-width: 150px;
+	width:20%;
+}


### PR DESCRIPTION
Since it is unreadable on a small desktop screen and not really nice on a big desktop screen, here are a few hackish fixes:
- rendering the date field to be at least of 100px width, since it's enough to display its content
- giving a max-width of 150px to the helper field, since it's not useful to have the full sentence displayed unless clicked
- giving a min-width of 70px to the values fields, since its the most important one, so we should always see what's inside at least up to the thousands
- giving a max-width of 100px to the VAT field, since we just need the % to be displayed
- setting a min-width of 170px to the dropdown menu of the fields, so that it remains usable even in the case of the VAT field 
- setting a min-width of 200px to the label, since it's very important and must be readable
- fiddling around with the labels and proofs so that they becomes readable

Globally, it renders the cashbook edition usable without a big screen and renders it more comfortable on a big screen.

Here is a before/after : 
![before_css_cashbook_1](https://cloud.githubusercontent.com/assets/10077203/15808935/c7211d80-2b84-11e6-9939-2130c662e0a1.png)
Which is almost non usable.
And after (the black part on the left hasn't changed, it's just not centered on the same point) :
![after_css_cashbook_1](https://cloud.githubusercontent.com/assets/10077203/15808934/c720e95a-2b84-11e6-8295-49966137568b.png)

I know a few of those changes are a little bit _hack-ish_, but certain parts just won't follow their width settings correctly (label and proof are really hard to resize, for example, and I didn't figured out yet where it comes from).
