### PR TITLE
Clean up display mode for reservations with multiple items

### DIFF
--- a/truffe2/logistics/models.py
+++ b/truffe2/logistics/models.py
@@ -554,7 +554,15 @@ Tu peux gérer ici la liste de réservation du matériel de l'unité active.""")
             raise forms.ValidationError(_(u'La date de fin ne peut pas être avant la date de début !'))
 
     def get_supply_link(self):
-        return u' '.join([u'<a href="{}">{}{}</a>'.format(reverse('logistics.views.supply_show', args=(line.supply.pk,)), u'{} * '.format(line.quantity) if line.quantity > 1 else '', line.supply) for line in self.lines.order_by('order')])
+        line_link_list = '<ul class="supply-items">'
+
+        for line in self.lines.order_by('order'):
+            line_link_list += '<li><span>'
+            line_link_list += u'<a href="{}">{}{}</a>'.format(reverse('logistics.views.supply_show', args=(line.supply.pk,)), line.supply, u' * {}'.format(line.quantity))
+            line_link_list += '</span></li>'
+
+        line_link_list += '</ul>'
+        return u'{}'.format(line_link_list)
 
     def get_supplies(self):
         return u' '.join([u'{}{}'.format(u'{} * '.format(line.quantity) if line.quantity > 1 else '', line.supply.title) for line in self.lines.order_by('order')])

--- a/truffe2/logistics/models.py
+++ b/truffe2/logistics/models.py
@@ -558,7 +558,7 @@ Tu peux gérer ici la liste de réservation du matériel de l'unité active.""")
 
         for line in self.lines.order_by('order'):
             line_link_list += '<li><span>'
-            line_link_list += u'<a href="{}">{}{}</a>'.format(reverse('logistics.views.supply_show', args=(line.supply.pk,)), line.supply, u' * {}'.format(line.quantity))
+            line_link_list += u'<a href="{}">{}{}</a>'.format(reverse('logistics.views.supply_show', args=(line.supply.pk,)), u'{} * '.format(line.quantity), line.supply)
             line_link_list += '</span></li>'
 
         line_link_list += '</ul>'

--- a/truffe2/media/css/truffe.css
+++ b/truffe2/media/css/truffe.css
@@ -168,7 +168,7 @@
 
 .desktop-detected .line_field_lines_value_ttc {
     min-width:100px;
-    max-width:120px;  
+    max-width:120px;
     width:6%;
 }
 
@@ -188,4 +188,17 @@
 .desktop-detected .line_field_lines_proof {
     min-width: 150px;
     width:20%;
+}
+
+.supply-items {
+    padding-left: 10px;
+}
+
+.supply-items li {
+    padding-bottom: 5px;
+}
+
+.supply-items li span {
+    display: block;
+    margin-left: -8px;
 }


### PR DESCRIPTION
Fix the way supply multiple reservations are shown, to make the RespLog life's easier!

Go from: 
![image](https://cloud.githubusercontent.com/assets/1197161/21652439/ef140fb2-d2ac-11e6-888e-6b36004e342b.png)

To:

![image](https://cloud.githubusercontent.com/assets/1197161/21652444/f4723362-d2ac-11e6-85f2-c594042fe8b5.png)