### PR TITLE
Show only distinct items in json lists

### DIFF
--- a/truffe2/generic/views.py
+++ b/truffe2/generic/views.py
@@ -267,11 +267,11 @@ def generate_list_related_json(module, base_name, model_class):
 
         if unit_mode:
             if hasattr(model_class.MetaState, 'filter_unit_field'):
-                filter_ = lambda x: x.filter(**{model_class.MetaState.filter_unit_field.replace('.', '__'): current_unit})
+                filter_ = lambda x: x.filter(**{model_class.MetaState.filter_unit_field.replace('.', '__'): current_unit}).distinct()
             else:
-                filter_ = lambda x: x.filter(**{model_class.MetaState.unit_field.replace('.', '__'): current_unit})
+                filter_ = lambda x: x.filter(**{model_class.MetaState.unit_field.replace('.', '__'): current_unit}).distinct()
         else:
-            filter_ = lambda x: x
+            filter_ = lambda x: x.distinct()
 
         if year_mode:
             filter__ = lambda x: filter_(x).filter(accounting_year=current_year)


### PR DESCRIPTION
Problem: Supply reservations show up multiple times due to containing multiple supply items.
Fix: .distinct() added to filter.

NB: either had to add .distinct() to the three lines as done, or had to create a filter__ = lambda x : filter_(x).distinct, and then update all the existing filter__ to filter___ (which seems ridiculous to me)