### PR TITLE
Update pip-reqs.txt

### DIFF
--- a/truffe2/data/pip-reqs.txt
+++ b/truffe2/data/pip-reqs.txt
@@ -8,7 +8,7 @@ requests
 django-impersonate<1
 pytz
 git+https://github.com/goinnn/django-multiselectfield
-easy_thumbnails
+easy_thumbnails<=2.5
 bleach<1.5
 python-ldap
 pisa


### PR DESCRIPTION
easy thumbnails v 2.6 create a bug in when intslling packages with pip
so we need to force it <=2.5