### PR TITLE
Catch errors on notif mail sending

### DIFF
--- a/truffe2/app/utils.py
+++ b/truffe2/app/utils.py
@@ -11,6 +11,7 @@ from django.contrib.sites.models import get_current_site
 from django.shortcuts import render
 
 
+import logging
 import cgi
 import ho.pisa as pisa
 import cStringIO as StringIO
@@ -119,7 +120,12 @@ def send_templated_mail(request, subject, email_from, emails_to, template, conte
 
     msg = EmailMultiAlternatives(subject, text_content, settings.EMAIL_FROM, emails_to)
     msg.attach_alternative(html_content, "text/html")
-    msg.send()
+
+    try:
+        msg.send()
+    except Exception as e:
+        logger = logging.getLogger(__name__)
+        logger.exception(e)
 
 
 def get_property(obj, prop):

--- a/truffe2/notifications/management/commands/process_notifications.py
+++ b/truffe2/notifications/management/commands/process_notifications.py
@@ -41,9 +41,11 @@ class Command(BaseCommand):
                     context = {
                         'notification': notification.notification,
                     }
-
-                    send_templated_mail(None, _(u'Truffe :: Notification :: {}'.format(notification.notification.key)), 'nobody@truffe.agepoly.ch', [user.email], 'notifications/mails/new_notif', context)
-
+ 
+                    try:
+                        send_templated_mail(None, _(u'Truffe :: Notification :: {}'.format(notification.notification.key)), 'nobody@truffe.agepoly.ch', [user.email], 'notifications/mails/new_notif', context)
+                    except Exception as e:
+                        print("Catched error while sending notification: {}".format(e)) 
                 if groups_notifications:
 
                     keys = []
@@ -55,8 +57,10 @@ class Command(BaseCommand):
                     context = {
                         'notifications': map(lambda n: n.notification, groups_notifications),
                     }
-
-                    send_templated_mail(None, _(u'Truffe :: Notifications ({}) :: {}'.format(len(groups_notifications), ', '.join(keys))), 'nobody@truffe.agepoly.ch', [user.email], 'notifications/mails/new_notifs', context)
+                    try:
+                        send_templated_mail(None, _(u'Truffe :: Notifications ({}) :: {}'.format(len(groups_notifications), ', '.join(keys))), 'nobody@truffe.agepoly.ch', [user.email], 'notifications/mails/new_notifs', context)
+                    except Exception as e:
+                        print("Catched error while sending notification: {}".format(e)) 
 
                 for notification in notifications:
                     notification.delete()

--- a/truffe2/notifications/management/commands/process_notifications.py
+++ b/truffe2/notifications/management/commands/process_notifications.py
@@ -41,11 +41,8 @@ class Command(BaseCommand):
                     context = {
                         'notification': notification.notification,
                     }
- 
-                    try:
-                        send_templated_mail(None, _(u'Truffe :: Notification :: {}'.format(notification.notification.key)), 'nobody@truffe.agepoly.ch', [user.email], 'notifications/mails/new_notif', context)
-                    except Exception as e:
-                        print("Catched error while sending notification: {}".format(e)) 
+                    send_templated_mail(None, _(u'Truffe :: Notification :: {}'.format(notification.notification.key)), 'nobody@truffe.agepoly.ch', [user.email], 'notifications/mails/new_notif', context)
+
                 if groups_notifications:
 
                     keys = []
@@ -57,10 +54,7 @@ class Command(BaseCommand):
                     context = {
                         'notifications': map(lambda n: n.notification, groups_notifications),
                     }
-                    try:
-                        send_templated_mail(None, _(u'Truffe :: Notifications ({}) :: {}'.format(len(groups_notifications), ', '.join(keys))), 'nobody@truffe.agepoly.ch', [user.email], 'notifications/mails/new_notifs', context)
-                    except Exception as e:
-                        print("Catched error while sending notification: {}".format(e)) 
+                    send_templated_mail(None, _(u'Truffe :: Notifications ({}) :: {}'.format(len(groups_notifications), ', '.join(keys))), 'nobody@truffe.agepoly.ch', [user.email], 'notifications/mails/new_notifs', context)
 
                 for notification in notifications:
                     notification.delete()


### PR DESCRIPTION
Avoid one problematic (non existent per instance) to block the whole notification command 